### PR TITLE
For connected network name, replace networksetup with ipconfig.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 ## v2.19.0
 
 * Replace `networksetup` with Swift script for connecting to a network.
+* For getting connected network name, replace `networksetup` with `ipconfig`. 
 
 ## v2.18.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 ## v2.19.0
 
-* Replace `netwoksetup` with Swift script for connecting to a network.
+* Replace `networksetup` with Swift script for connecting to a network.
 
 ## v2.18.0
 

--- a/lib/wifi-wand/models/mac_os_model.rb
+++ b/lib/wifi-wand/models/mac_os_model.rb
@@ -162,10 +162,10 @@ class MacOsModel < BaseModel
   def connected_network_name
     return nil unless wifi_on? # no need to try
 
-    command_output = run_os_command("networksetup -getairportnetwork #{wifi_interface}")
-    connected_prefix = 'Current Wi-Fi Network: '
-    connected = Regexp.new(connected_prefix).match?(command_output)
-    connected ? command_output.split(connected_prefix).last.chomp : nil
+    command_output = run_os_command("ipconfig getsummary #{wifi_interface} | grep ' SSID :'", false)
+    return nil if command_output.nil?
+
+    command_output.split('SSID :').last.strip
   end
 
 

--- a/lib/wifi-wand/version.rb
+++ b/lib/wifi-wand/version.rb
@@ -1,3 +1,3 @@
 module WifiWand
-  VERSION = '2.18.0' unless defined?(VERSION)
+  VERSION = '2.19.0' unless defined?(VERSION)
 end


### PR DESCRIPTION
Addresses issue https://github.com/keithrbennett/wifiwand/issues/30.

For getting currently connected network name, replaces:

```ruby
networksetup -getairportnetwork #{wifi_interface}
```

with:

```ruby
ipconfig getsummary #{wifi_interface}
```

...because in Mac OS Sequoia (15), the former no longer returns a name.
