### PR TITLE
Change some calls to use `system_profiler` JSON output.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,13 @@
+## v2.20.0
+
+* For detecting the wifi interface (e.g. 'en0'), replace networksetup with system_profiler.
+* For listing available networks, replace Swift script with system_profiler. Now sorts in signal strength order and removes duplicates.
+* Cleanup and refactoring in BaseModel and CommandLineInterface.
+
 ## v2.19.0
 
-* Replace `netwoksetup` with Swift script for connecting to a network.
+* Replace `networksetup` with Swift script for connecting to a network.
+* For getting connected network name, replace `networksetup` with `ipconfig`. 
 
 ## v2.18.0
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+## v2.20.0
+
+* Change detect_wifi_interface and available_network_names to use system_profiler JSON output.
+* Previously, detect_wifi_interface parsed human readable text; parsing JSON is more reliable.
+* Previously, available_network_names used Swift and CoreLAN and required XCode installation.
+
+
 ## v2.19.1
 
 * Fix connected_network_name when wifi is on but no network is connected.

--- a/lib/wifi-wand/command_line_interface.rb
+++ b/lib/wifi-wand/command_line_interface.rb
@@ -219,9 +219,17 @@ When in interactive shell mode:
       if post_processor
         puts post_processor.(info)
       else
-        puts model.wifi_on? \
-            ? "Available networks are:\n\n#{fancy_string(info)}" \
-            : "Wifi is off, cannot see available networks."
+        message = if model.wifi_on?
+          <<~MESSAGE
+            Available networks, in descending signal strength order, 
+            and not including any currently connected network, are:
+  
+            #{fancy_string(info)}"
+          MESSAGE
+        else
+          "Wifi is off, cannot see available networks."
+        end
+        puts message
       end
     end
   end

--- a/lib/wifi-wand/models/mac_os_model.rb
+++ b/lib/wifi-wand/models/mac_os_model.rb
@@ -55,7 +55,7 @@ class MacOsModel < BaseModel
 
     # run_swift_command('AvailableWifiNetworkLister').split("\n").uniq
 
-      json_text = run_os_command('system_profiler -json SPAirPortDataType')
+    json_text = run_os_command('system_profiler -json SPAirPortDataType')
     data = JSON.parse(json_text)
 
     inner_key = connected_network_name ? 'spairport_airport_other_local_wireless_networks' : 'spairport_airport_local_wireless_networks'

--- a/lib/wifi-wand/models/mac_os_model.rb
+++ b/lib/wifi-wand/models/mac_os_model.rb
@@ -16,7 +16,7 @@ class MacOsModel < BaseModel
 
   # Identifies the (first) wireless network hardware interface in the system, e.g. en0 or en1
   # This may not detect wifi ports with nonstandard names, such as USB wifi devices.
-  def detect_wifi_interface
+  def detect_wifi_interface_using_networksetup
 
     lines = run_os_command("networksetup -listallhardwareports").split("\n")
     # Produces something like this:
@@ -37,6 +37,16 @@ class MacOsModel < BaseModel
     else
       lines[wifi_interface_line_num + 1].split(': ').last
     end
+  end
+
+  # Identifies the (first) wireless network hardware interface in the system, e.g. en0 or en1
+  # This may not detect wifi ports with nonstandard names, such as USB wifi devices.
+  def detect_wifi_interface
+    json_text = run_os_command('system_profiler -json SPNetworkDataType')
+    net_data = JSON.parse(json_text)
+    nets = net_data['SPNetworkDataType']
+    wifi = nets.detect { |net| net['_name'] == 'Wi-Fi'}
+    wifi['interface']
   end
 
   def available_network_names

--- a/lib/wifi-wand/models/mac_os_model.rb
+++ b/lib/wifi-wand/models/mac_os_model.rb
@@ -57,11 +57,12 @@ class MacOsModel < BaseModel
 
     json_text = run_os_command('system_profiler -json SPAirPortDataType')
     data = JSON.parse(json_text)
+
     nets = data['SPAirPortDataType'] \
       .detect { |h| h['spairport_airport_interfaces'] } \
       ['spairport_airport_interfaces'] \
       .detect { |h| h['_name'] == wifi_interface } \
-      ['spairport_airport_other_local_wireless_networks'] \
+      ['spairport_airport_local_wireless_networks'] \
       .sort_by { |net| -net['spairport_signal_noise'].split('/').first.to_i }
     nets.map { |h| h['_name']}.uniq
   end

--- a/lib/wifi-wand/models/mac_os_model.rb
+++ b/lib/wifi-wand/models/mac_os_model.rb
@@ -55,15 +55,17 @@ class MacOsModel < BaseModel
 
     # run_swift_command('AvailableWifiNetworkLister').split("\n").uniq
 
-    json_text = run_os_command('system_profiler -json SPAirPortDataType')
+      json_text = run_os_command('system_profiler -json SPAirPortDataType')
     data = JSON.parse(json_text)
 
+    inner_key = connected_network_name ? 'spairport_airport_other_local_wireless_networks' : 'spairport_airport_local_wireless_networks'
+
     nets = data['SPAirPortDataType'] \
-      .detect { |h| h['spairport_airport_interfaces'] } \
-      ['spairport_airport_interfaces'] \
-      .detect { |h| h['_name'] == wifi_interface } \
-      ['spairport_airport_local_wireless_networks'] \
-      .sort_by { |net| -net['spairport_signal_noise'].split('/').first.to_i }
+       .detect { |h| h.key?('spairport_airport_interfaces') } \
+        ['spairport_airport_interfaces'] \
+       .detect { |h| h['_name'] == wifi_interface } \
+        [inner_key] \
+        .sort_by { |net| -net['spairport_signal_noise'].split('/').first.to_i }
     nets.map { |h| h['_name']}.uniq
   end
 
@@ -184,10 +186,10 @@ class MacOsModel < BaseModel
   def connected_network_name
     return nil unless wifi_on? # no need to try
 
-    command_output = run_os_command("networksetup -getairportnetwork #{wifi_interface}")
-    connected_prefix = 'Current Wi-Fi Network: '
-    connected = Regexp.new(connected_prefix).match?(command_output)
-    connected ? command_output.split(connected_prefix).last.chomp : nil
+    command_output = run_os_command("ipconfig getsummary #{wifi_interface} | grep ' SSID :'", false)
+    return nil if command_output.empty?
+
+    command_output.split('SSID :').last.strip
   end
 
 

--- a/lib/wifi-wand/version.rb
+++ b/lib/wifi-wand/version.rb
@@ -1,3 +1,3 @@
 module WifiWand
-  VERSION = '2.19.1' unless defined?(VERSION)
+  VERSION = '2.20.0' unless defined?(VERSION)
 end

--- a/lib/wifi-wand/version.rb
+++ b/lib/wifi-wand/version.rb
@@ -1,3 +1,3 @@
 module WifiWand
-  VERSION = '2.18.0' unless defined?(VERSION)
+  VERSION = '2.19.0' unless defined?(VERSION)
 end


### PR DESCRIPTION
Addresses issue #36.

Changes implementations of the `detect_wifi_interface` and `available_network_names` methods to use `system_profiler`'s JSON output.